### PR TITLE
chore: release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.1.0] - 2025-08-14
+### Changed
+- Bumped package version to `1.1.0`.
+- Added this changelog to document future updates.
+
+### Fixed
+- Corrected package metadata in `package-lock.json` to match the published version.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekogd/react-hook-npm-publish-boilerplate",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekogd/react-hook-npm-publish-boilerplate",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-sortable",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Modular utility hooks that we often use grouped in one package. Written in TypeScript, documented, tested and maintained.Disclaimer: at least React 16 is needed (the one with hooks ;) )",
   "main": "index.js",
   "module": "index.esm.js",


### PR DESCRIPTION
## Summary
- bump package version to 1.1.0
- add changelog for 1.1.0 release
- align package-lock metadata with new version

## Testing
- `npm test`
- `npm publish --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_689d43ab9e808332a63610f3f32fdc20